### PR TITLE
Provide device serial number.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ Usage
        print("  VendorId: 0x%04x" % dev["vendor_id"])
        print("  ProductId: 0x%04x" % dev["product_id"])
        print("  ProductDesc:", dev["product_desc"])
+       print("  SerialNumber:", dev["serial_number"])
        fd = os.open(dev["path"], os.O_RDONLY)
        out = uhid.get_report_data(fd, 3)
        os.close(fd)

--- a/test.py
+++ b/test.py
@@ -9,6 +9,7 @@ for dev in uhid.enumerate():
     print("  VendorId: 0x%04x" % dev["vendor_id"])
     print("  ProductId: 0x%04x" % dev["product_id"])
     print("  ProductDesc:", dev["product_desc"])
+    print("  SerialNumber:", dev["serial_number"])
     fd = os.open(dev["path"], os.O_RDONLY)
     out = uhid.get_report_data(fd, 3)
     os.close(fd)


### PR DESCRIPTION
Return a device's serial number if one can be found in the `%pnpinfo`.

I have tested this on FreeBSD 12.2 running in a virtual machine, using python3.7 (only) and a FIDO2 key.